### PR TITLE
Add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 _build
+
+# nix ignores
+.direnv
+result
+.envrc
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,63 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1708807242,
+        "narHash": "sha256-sRTRkhMD4delO/hPxxi+XwLqPn8BuUq6nnj4JqLwOu0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "73de017ef2d18a04ac4bfd0c02650007ccb31c2a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1706550542,
+        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "Example kickstart OCaml application project.";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+      perSystem = { config, self', inputs', pkgs, system, ... }:
+        let
+          inherit (pkgs) ocamlPackages mkShell;
+          inherit (ocamlPackages) buildDunePackage;
+          name = "colors";
+          version = "0.0.1";
+        in
+        {
+          devShells = {
+            default = mkShell {
+	      buildInputs = [ ocamlPackages.utop ];
+              inputsFrom = [ self'.packages.default ];
+            };
+          };
+
+          packages = {
+            default = buildDunePackage {
+              inherit version;
+              pname = name;
+	      propagatedBuildInputs = with ocamlPackages; [
+            	(mdx.override {
+              	  inherit logs;
+            	})
+	      ];
+              src = ./.;
+            };
+	  };
+        };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Example kickstart OCaml application project.";
+  description = "A pure OCaml library for manipulating colors in different color spaces";
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 


### PR DESCRIPTION
This PR adds a derivation using nix flakes to allow building colors with nix with support for the following architectures:
`"x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"`

It is currently using OCaml 5.1 as that is the version in nix-pkgs. We could work on an improvement of this flake to support earlier versions of the compiler if there's demand.
